### PR TITLE
PR: hotfix/color-selector-v1

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -75,7 +75,7 @@ const observer = new MutationObserver((mutations) => {
 });
 
 let enabled = false;
-let highlightColor = "#FFFF00";
+let highlightColor = "#FFF4B3";
 const keys: ("enabled" | "item")[] = ["enabled", "item"];
 let initComplete = false;
 let cachedPageKey: string | null = null;
@@ -909,11 +909,11 @@ function addHighlight() {
 // Helper function to get the next color from the rotation
 function getNextHighlightColor(): string {
   const highlightColors = [
-    "#FFFF00", // Yellow
-    "#7FFFD4", // Aquamarine
-    "#FF69B4", // Hot Pink
-    "#FFA500", // Orange
-    "#00FFFF", // Cyan
+    "#FFF4B3", // Butter Yellow
+    "#FFD1DC", // Cotton Candy Pink
+    "#B5EAD7", // Mint
+    "#C7CEEA", // Periwinkle
+    "#FFDAC1", // Peach
   ];
 
   // Get the current index from storage or use 0 as default

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -169,7 +169,7 @@ document.addEventListener("DOMContentLoaded", () => {
         colorPicker.click();
         e.stopPropagation();
       } else {
-        const color = swatch.dataset.color ?? "#ffff00";
+        const color = swatch.dataset.color ?? "#FFF4B3";
         updateSelectedColor(color);
       }
     });
@@ -208,7 +208,7 @@ document.addEventListener("DOMContentLoaded", () => {
       const extensionEnabled = syncData.enabled === true;
       updateHighlightSectionState(extensionEnabled);
 
-      const savedColor = localData.highlightColor ?? "#ffff00";
+      const savedColor = localData.highlightColor ?? "#FFF4B3";
       colorPicker.value = savedColor;
       updateSelectedColor(savedColor);
     } catch (err) {

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "HylyTool",
   "description": "Chrome Extension for highlighting web documents",
-  "version": "0.1.0",
+  "version": "1.1.0",
   "manifest_version": 3,
   "icons": {
     "16": "icons/icon16.png",

--- a/static/popup.css
+++ b/static/popup.css
@@ -94,8 +94,14 @@ input:checked + .slider:before {
 
 section {
   background: #f8f9fa;
-  border-radius: 8px;
+  border-radius: 10px;
   padding: 16px;
+  box-shadow: 0 1px 2px rgba(17, 24, 39, 0.03);
+}
+
+.highlight-section {
+  background: linear-gradient(180deg, #fdfdff 0%, #f8f9fa 100%);
+  border: 1px solid #eef0f4;
 }
 
 section h2 {
@@ -181,12 +187,13 @@ input[type="color"]:focus {
 }
 
 .hidden-color-picker {
-  position: fixed !important;
-  left: -9999px !important;
-  top: -9999px !important;
+  position: absolute !important;
+  left: 0 !important;
+  top: 0 !important;
   width: 1px !important;
   height: 1px !important;
   opacity: 0 !important;
+  pointer-events: none !important;
   border: 0;
   padding: 0;
   overflow: hidden;
@@ -194,10 +201,15 @@ input[type="color"]:focus {
 
 /* Color swatches */
 .color-swatches {
+  position: relative;
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 8px;
+  gap: 10px;
+  margin-top: 10px;
+  padding: 10px;
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: inset 0 0 0 1px #eef0f4;
 }
 
 .color-swatches.disabled {
@@ -206,16 +218,22 @@ input[type="color"]:focus {
 }
 
 .color-swatch {
-  width: 30px;
-  height: 30px;
+  width: 32px;
+  height: 32px;
   border-radius: 50%;
-  border: 2px solid #ddd;
+  border: 2px solid rgba(255, 255, 255, 0.9);
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition:
+    transform 0.18s ease,
+    box-shadow 0.18s ease,
+    border-color 0.18s ease;
   padding: 0;
   display: flex;
   align-items: center;
   justify-content: center;
+  box-shadow:
+    0 1px 2px rgba(17, 24, 39, 0.08),
+    0 0 0 1px rgba(17, 24, 39, 0.06);
 }
 
 .color-swatch:disabled {
@@ -224,33 +242,88 @@ input[type="color"]:focus {
 }
 
 .color-swatch:hover {
-  transform: scale(1.1);
-  box-shadow: 0 0 5px rgba(0, 0, 0, 0.2);
+  transform: translateY(-1px) scale(1.08);
+  box-shadow:
+    0 4px 10px rgba(17, 24, 39, 0.12),
+    0 0 0 1px rgba(17, 24, 39, 0.08);
+}
+
+.color-swatch:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 3px rgba(33, 150, 243, 0.35),
+    0 2px 6px rgba(17, 24, 39, 0.12);
 }
 
 .color-swatch.selected {
-  border-color: #333;
-  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.2);
+  border-color: #ffffff;
+  box-shadow:
+    0 0 0 2px #2196f3,
+    0 2px 6px rgba(33, 150, 243, 0.25);
+  transform: scale(1.06);
 }
 
 .color-swatches.disabled .color-swatch.selected {
-  border-color: #ddd;
-  box-shadow: none;
+  border-color: rgba(255, 255, 255, 0.9);
+  box-shadow:
+    0 1px 2px rgba(17, 24, 39, 0.08),
+    0 0 0 1px rgba(17, 24, 39, 0.06);
+  transform: none;
 }
 
 .custom-color-button {
-  background-color: #f8f9fa;
+  position: relative;
+  background: conic-gradient(
+    from 0deg,
+    #ffd1dc,
+    #fff4b3,
+    #b5ead7,
+    #c7ceea,
+    #ffdac1,
+    #ffd1dc
+  );
+  color: transparent;
+  isolation: isolate;
+  overflow: hidden;
+}
+
+.custom-color-button::before {
+  content: "";
+  position: absolute;
+  inset: 3px;
+  border-radius: 50%;
+  background: #ffffff;
+  z-index: 0;
+  transition: inset 0.18s ease;
+}
+
+.custom-color-button::after {
+  content: "+";
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1;
   font-size: 20px;
-  font-weight: bold;
-  color: #666;
+  font-weight: 700;
+  color: #6b7280;
 }
 
 .custom-color-button:hover {
-  background-color: #e9ecef;
+  transform: translateY(-1px) scale(1.08) rotate(8deg);
 }
 
 .custom-color-button.custom-color-active {
-  color: transparent;
+  background: none;
+}
+
+.custom-color-button.custom-color-active::before {
+  display: none;
+}
+
+.custom-color-button.custom-color-active::after {
+  content: "";
 }
 
 .input-with-buttons {

--- a/static/popup.html
+++ b/static/popup.html
@@ -50,36 +50,44 @@
             <div class="color-swatches">
               <button
                 class="color-swatch"
-                data-color="#FFFF00"
-                style="background-color: #ffff00"
+                data-color="#FFF4B3"
+                style="background-color: #FFF4B3"
+                title="Butter Yellow"
               ></button>
               <button
                 class="color-swatch"
-                data-color="#7FFFD4"
-                style="background-color: #7fffd4"
+                data-color="#FFD1DC"
+                style="background-color: #FFD1DC"
+                title="Cotton Candy Pink"
               ></button>
               <button
                 class="color-swatch"
-                data-color="#FF69B4"
-                style="background-color: #ff69b4"
+                data-color="#B5EAD7"
+                style="background-color: #B5EAD7"
+                title="Mint"
               ></button>
               <button
                 class="color-swatch"
-                data-color="#FFA500"
-                style="background-color: #ffa500"
+                data-color="#C7CEEA"
+                style="background-color: #C7CEEA"
+                title="Periwinkle"
               ></button>
               <button
                 class="color-swatch"
-                data-color="#00FFFF"
-                style="background-color: #00ffff"
+                data-color="#FFDAC1"
+                style="background-color: #FFDAC1"
+                title="Peach"
               ></button>
-              <button class="color-swatch custom-color-button">+</button>
+              <button
+                class="color-swatch custom-color-button"
+                title="Pick a custom color"
+              >+</button>
             </div>
             <input
               type="color"
               id="color-picker"
               class="hidden-color-picker"
-              value="#ffff00"
+              value="#FFF4B3"
               aria-label="Choose custom highlight color"
             />
           </div>


### PR DESCRIPTION
## What was fixed

### Custom color picker not opening
The "+" button was calling `colorPicker.click()` correctly, but Chromium silently refuses to open the native color picker for an element positioned outside the viewport. The hidden input was sitting at `left/top: -9999px`, so the picker never appeared. Fixed by repositioning the input to `left: 0; top: 0` while keeping it invisible (`opacity: 0; pointer-events: none`).

### Highlight color palette
Replaced the five saturated preset colors (yellow, aquamarine, hot pink, orange, cyan) with a softer pastel palette: Butter Yellow, Cotton Candy Pink, Mint, Periwinkle, and Peach. Updated consistently across the popup and content script so the defaults match everywhere.

### Swatch UI polish
- Swatches sit in a white card container with a soft inset border
- Hover state lifts and scales the swatch with a subtle shadow
- Selected state shows a clean blue ring instead of a dark border
- "+" button uses a pastel conic-gradient ring with a white inner disc; rotates slightly on hover
- When a custom color is active, the "+" button fills with the chosen color

---

## Testing

- Confirmed the native picker opens on "+" click with the extension toggle on, and is blocked when off
- Verified selected color persists correctly on popup reopen
- Checked disabled state — swatches are muted and non-interactive when the extension is toggled off
- Custom color active state transitions cleanly back to a preset swatch when one is clicked
- Tested the fix via runtime logs: `change`/`input` events from the color picker were confirmed firing with real color values after the CSS change
